### PR TITLE
Don't generate leading 0x in node address

### DIFF
--- a/sopc2dts/lib/components/BasicComponent.java
+++ b/sopc2dts/lib/components/BasicComponent.java
@@ -146,7 +146,7 @@ public class BasicComponent extends BasicElement {
 	}
 	public DTNode toDTNode(BoardInfo bi,Connection conn)
 	{
-		DTNode node = new DTNode(getScd().getGroup() + "@0x" + getAddrFromConnectionStr(conn), instanceName);
+		DTNode node = new DTNode(getScd().getGroup() + "@" + getAddrFromConnectionStr(conn), instanceName);
 		DTProperty p;
 		if((getScd().getGroup().equalsIgnoreCase("cpu"))||(getScd().getGroup().equalsIgnoreCase("memory")))
 		{


### PR DESCRIPTION
When compiling the generated dts with dtc, it shows warnings like the
following:

  Warning (unit_address_format): Node /XXX unit name should not have leading "0x"

Don't generate the leading 0x anymore.

See https://marc.info/?i=20171214165359.28112-1-malat%40debian.org for
details.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>