### PR TITLE
Update sopc_components_altera.xml - Recognise altera_merlin_master_translator

### DIFF
--- a/sopc_components_altera.xml
+++ b/sopc_components_altera.xml
@@ -74,6 +74,10 @@
 	<S2DComponent classname="altera_address_span_extender"
 		group="bridge" compatDevice="avalon">
 	</S2DComponent>
+	<S2DComponent classname="altera_merlin_master_translator"
+		group="bridge" compatDevice="avalon">
+		<compatible name="simple-bus"></compatible>
+	</S2DComponent>
 	<S2DComponent classname="altera_reset_bridge" group="ignore"/>
 	<S2DComponent classname="altera_avalon_clock_crossing,altera_avalon_mm_clock_crossing_bridge,altera_avalon_pipeline_bridge,altera_avalon_mm_bridge,M64_32_bridge"
 		group="bridge" compatDevice="avalon">


### PR DESCRIPTION
The Avalon_MM_Translator is used to go from e.g. AXI to Avalon bus or adapt burst sizes. Components addressable by this bridge are omitted from the DTS. Adding these couple of lines makes that SOPC2DTS recognises this component.

